### PR TITLE
add possibility to specify extra elastic search parameters

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,6 +32,11 @@ module.exports = function(grunt) {
     elasticServer: 'myelasticserver.com',                               // The address of your elastic server
     elasticUser: 'myelasticuser',                                       // The read/write user on your elastic server
     elasticPassword: 'myelasticuserpassword',                           // The password for your elastic user
+    //elasticOptions: {                                                 // This block is completely optional but useful if you need to specify
+    //  port: 9200,                                                     // more elasticsearch options. Possible keys are :
+    //  secure: false,                                                  // port, secure, defaultMethod, params, path, timeout, keepAlive and agent
+    //  defaultMethod: 'GET'                                            // Uncomment this block and fill in your required values if needed
+    //},
     googleProjectId: 'mygoogleproject',                                 // Your google project ID. Usually something like whatever-123
     sitesBucket: 'your-company-name-sites',                             // The name of the build bucket on Google Cloud Storage
     backupBucket: 'your-company-name-backups',                          // The name of the backup bucket on Google Cloud Storage

--- a/libs/server.js
+++ b/libs/server.js
@@ -23,6 +23,7 @@ var temp = require('temp');
 var mime = require('mime');
 var ElasticSearchClient = require('elasticsearchclient');
 var archiver   = require('archiver');
+var _ = require('lodash');
 
 // Some string functions worth having
 String.prototype.endsWith = function(suffix) {
@@ -89,6 +90,10 @@ module.exports.start = function(config, logger)
         password: config.get('elasticPassword')
     }
   };
+  if (config.get('elasticOptions'))
+  {
+    _.extend(elasticOptions, config.get('elasticOptions'));
+  }
 
   var elastic = new ElasticSearchClient(elasticOptions);
   


### PR DESCRIPTION
This fixes the issue I was having with using another elastic search provider than found.no and they are using https and port 443.

I added an optional parameter elasticOptions that is an object which can contain any extra parameter needed for elastic search and I added plenty of comments to explain what this object does. It also doesn't change how the other parameters were handled so it is backwards compatible. 
